### PR TITLE
Allow users to have primary group specified

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@
 #
 # `user` is the name of the Unix account
 # `name` is the user's name, optional, just for documentation
-# `group` is user's primary group, optional, will use user value if undefined
+# `group` is user's primary group, optional.
 # `key` is a ssh public key file
 # `github` is the user's GitHub id
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,10 +9,11 @@
 # users_app_user: foo
 # users_app_group: foo
 
-# User accounts and ssh keys for the people or other automated users. 
+# User accounts and ssh keys for the people or other automated users.
 #
 # `user` is the name of the Unix account
 # `name` is the user's name, optional, just for documentation
+# `group` is user's primary group, optional, will use user value if undefined
 # `key` is a ssh public key file
 # `github` is the user's GitHub id
 #
@@ -22,6 +23,7 @@
 #     github: reachfh
 #   - user: ci
 #     name: "CI server"
+#     group: devops
 #     key: ci.pub
 users_users: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,12 +59,14 @@
 # http://docs.ansible.com/ansible/user_module.html
 - name: Add admin users
   user:
-    name: "{{ item }}"
+    name: "{{ item.user }}"
+    group: "{{ item.group | default(omit) }}"
     groups: "{{ users_admin_groups | join(',') }}"
-    comment: "ansible-{{ item }}"
+    comment: "ansible-{{ item.user }}"
     shell: /bin/bash
     append: no
-  with_items: "{{ users_global_admin_users | union(users_admin_users) }}"
+  with_items: "{{ users_users }}"
+  when: "item.user in admin_users"
 
 # http://docs.ansible.com/ansible/authorized_key_module.html
 - name: Set ssh keys for admin users from files
@@ -90,11 +92,13 @@
 
 - name: Add regular users
   user:
-    name: "{{ item }}"
+    name: "{{ item.user }}"
+    group: "{{ item.group | default(item.user) }}"
     groups: "{{ users_regular_groups | join(',') }}"
-    comment: "ansible-{{ item }}"
+    comment: "ansible-{{ item.user }}"
     shell: /bin/bash
-  with_items: "{{ users_regular_users }}"
+  with_items: "{{ users_users }}"
+  when: "item.user in users_regular_users"
 
 - name: Set ssh keys for regular users from files
   authorized_key:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,7 +93,7 @@
 - name: Add regular users
   user:
     name: "{{ item.user }}"
-    group: "{{ item.group | default(item.user) }}"
+    group: "{{ item.group | default(omit) }}"
     groups: "{{ users_regular_groups | join(',') }}"
     comment: "ansible-{{ item.user }}"
     shell: /bin/bash


### PR DESCRIPTION
This PR allows the users defined in `users_users` to have a `group` attribute - setting the primary group for individuals if required.

I updated the logic around admin and regular user creation so that both loop over the `users_users` variable, but conditionally create based on the `item.user` value being present in `admin_users` or `users_regular_users` respectively.